### PR TITLE
Added filterBranches function to treeview component

### DIFF
--- a/treeview/treeview.js
+++ b/treeview/treeview.js
@@ -545,7 +545,20 @@ angular.module('servoyextraTreeview',['servoy']).directive('servoyextraTreeview'
       			}
       		}
       	}
-      	
+		  
+		$scope.api.filterBranches = function(text) {
+			if(theTree) {
+				if (text) {
+					var rexExp = new RegExp(text, "i");
+					theTree.filterBranches(function(node) {
+						return rexExp.test(node.title);
+					  });
+				} else {
+					theTree.clearFilter();
+				}
+			}
+		}
+
       },
       templateUrl: 'servoyextra/treeview/treeview.html'
     };

--- a/treeview/treeview.js
+++ b/treeview/treeview.js
@@ -546,13 +546,10 @@ angular.module('servoyextraTreeview',['servoy']).directive('servoyextraTreeview'
       		}
       	}
 		  
-		$scope.api.filterBranches = function(text) {
+		$scope.api.filterBranches = function(text, options) {
 			if(theTree) {
 				if (text) {
-					var rexExp = new RegExp(text, "i");
-					theTree.filterBranches(function(node) {
-						return rexExp.test(node.title);
-					  });
+					theTree.filterBranches(text, options);
 				} else {
 					theTree.clearFilter();
 				}

--- a/treeview/treeview.spec
+++ b/treeview/treeview.spec
@@ -195,6 +195,10 @@
       						{
       						"name":"text",
       						"type":"string"
+      						}, {
+      						"name":"options",
+      						"type":"object",
+      						"optional":true
       						}
       					]
       	}

--- a/treeview/treeview.spec
+++ b/treeview/treeview.spec
@@ -188,8 +188,15 @@
       						"type":"object",
       						"optional":true
       						}
-      					],     	
-      		"returns": "int"
+      					]
+		},
+      	"filterBranches": {
+      		"parameters":[
+      						{
+      						"name":"text",
+      						"type":"string"
+      						}
+      					]
       	}
 	}
 }


### PR DESCRIPTION
Expanded on treeview component:
Added an extra function to filter branches instead of nodes only.
This way the filter will also search the branches and show both branches and its children (nodes)

Also fixed a wrong return type on filterNodes function (should be void)