### PR TITLE
SVY-20331 Sidenav contained form not displayed on refresh

### DIFF
--- a/projects/servoyextracomponents/src/sidenav/sidenav.ts
+++ b/projects/servoyextracomponents/src/sidenav/sidenav.ts
@@ -937,6 +937,7 @@ export class ServoyExtraSidenav extends ServoyBaseComponent<HTMLDivElement> {
 	private copyServoyMenu() {
 		if (this.servoyMenu) {
 			this.selectedIndex = {};
+			this.expandedIndex = {};
 			const selectedNode = {};
 			const oldMenu = new Array();
 			if (this.servoyMenu.items) {


### PR DESCRIPTION
Reset the expandedIndex object when initialising the servoyMenu to allow the sidenav to re-initialise correctly on page refresh.